### PR TITLE
Fixes to make plugin work again with meross API changes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.2
+current_version = 0.13.3
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.dev(?P<dev>.*))?

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 setuptools.setup(
     name="OctoPrint-PSUControl-Meross",
-    version="0.13.2",
+    version="0.13.3",
     description="Adds Meross Smart Plug support to OctoPrint-PSUControl",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setuptools.setup(
     entry_points={
         "octoprint.plugin": ["psucontrol_meross = octoprint_psucontrol_meross"]
     },
-    install_requires=["OctoPrint>=1.7.3", "meross-iot>=0.4.5.4"],
+    install_requires=["OctoPrint>=1.7.3", "meross-iot>=0.4.6.0"],
     python_requires=">=3.7.3",
 )

--- a/src/octoprint_psucontrol_meross/__init__.py
+++ b/src/octoprint_psucontrol_meross/__init__.py
@@ -1,4 +1,4 @@
-__VERSION__ = "0.13.1"
+__VERSION__ = "0.13.3"
 __author__ = "Ilja Orlovs <vrghost@gmail.com>"
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"
 __copyright__ = (

--- a/src/octoprint_psucontrol_meross/meross_client.py
+++ b/src/octoprint_psucontrol_meross/meross_client.py
@@ -236,11 +236,11 @@ class _OctoprintPsuMerossClientAsync:
             ]
         )
         out = []
-        for device_hanle, (dev_uuid, dev_channel) in zip(devices, uuid_channel_pairs):
-            if not device_hanle:
+        for device_handle, (dev_uuid, dev_channel) in zip(devices, uuid_channel_pairs):
+            if not device_handle:
                 self._logger.error(f"Device {dev_uuid!r} not found.")
                 continue
-            out.append((device_hanle, dev_channel))
+            out.append((device_handle, dev_channel))
         return out
 
     async def set_devices_states(self, dev_ids: Sequence[str], state: bool):

--- a/src/octoprint_psucontrol_meross/plugin.py
+++ b/src/octoprint_psucontrol_meross/plugin.py
@@ -43,11 +43,11 @@ class PSUControlMeross(
     def get_settings_defaults(self):
         return {
             "api_urls": [
-                {"name": "Asia-Pacific", "url": "https://iotx-ap.meross.com"},
-                {"name": "Europe", "url": "https://iotx-eu.meross.com"},
-                {"name": "US", "url": "https://iotx-us.meross.com"},
+                {"name": "Asia-Pacific", "url": "iotx-ap.meross.com"},
+                {"name": "Europe", "url": "iotx-eu.meross.com"},
+                {"name": "US", "url": "iotx-us.meross.com"},
             ],
-            "api_base_url": "https://iotx-eu.meross.com",
+            "api_base_url": "iotx-eu.meross.com",
             "user_email": "",
             "user_password": "",
             "target_device_ids": [],

--- a/src/octoprint_psucontrol_meross/plugin.py
+++ b/src/octoprint_psucontrol_meross/plugin.py
@@ -43,11 +43,11 @@ class PSUControlMeross(
     def get_settings_defaults(self):
         return {
             "api_urls": [
-                {"name": "Asia-Pacific", "url": "iotx-ap.meross.com"},
-                {"name": "Europe", "url": "iotx-eu.meross.com"},
-                {"name": "US", "url": "iotx-us.meross.com"},
+                {"name": "Asia-Pacific", "url": 'iotx-ap.meross.com'},
+                {"name": "Europe", "url": 'iotx-eu.meross.com'},
+                {"name": "US", "url": 'iotx-us.meross.com'},
             ],
-            "api_base_url": "iotx-eu.meross.com",
+            "api_base_url": 'iotx-eu.meross.com',
             "user_email": "",
             "user_password": "",
             "target_device_ids": [],

--- a/src/octoprint_psucontrol_meross/plugin.py
+++ b/src/octoprint_psucontrol_meross/plugin.py
@@ -43,11 +43,11 @@ class PSUControlMeross(
     def get_settings_defaults(self):
         return {
             "api_urls": [
-                {"name": "Asia-Pacific", "url": 'iotx-ap.meross.com'},
-                {"name": "Europe", "url": 'iotx-eu.meross.com'},
-                {"name": "US", "url": 'iotx-us.meross.com'},
+                {"name": "Asia-Pacific", "url": "https://iotx-ap.meross.com"},
+                {"name": "Europe", "url": "https://iotx-eu.meross.com"},
+                {"name": "US", "url": "https://iotx-us.meross.com"},
             ],
-            "api_base_url": 'iotx-eu.meross.com',
+            "api_base_url": "https://iotx-eu.meross.com",
             "user_email": "",
             "user_password": "",
             "target_device_ids": [],

--- a/src/octoprint_psucontrol_meross/plugin.py
+++ b/src/octoprint_psucontrol_meross/plugin.py
@@ -43,11 +43,11 @@ class PSUControlMeross(
     def get_settings_defaults(self):
         return {
             "api_urls": [
-                {"name": "Asia-Pacific", "url": "iotx-ap.meross.com"},
-                {"name": "Europe", "url": "iotx-eu.meross.com"},
-                {"name": "US", "url": "iotx-us.meross.com"},
+                {"name": "Asia-Pacific", "url": "https://iotx-ap.meross.com"},
+                {"name": "Europe", "url": "https://iotx-eu.meross.com"},
+                {"name": "US", "url": "https://iotx-us.meross.com"},
             ],
-            "api_base_url": "iotx-us.meross.com",
+            "api_base_url": "https://iotx-eu.meross.com",
             "user_email": "",
             "user_password": "",
             "target_device_ids": [],

--- a/src/octoprint_psucontrol_meross/templates/psucontrol_meross_settings.jinja2
+++ b/src/octoprint_psucontrol_meross/templates/psucontrol_meross_settings.jinja2
@@ -37,7 +37,7 @@
                             options: settings.api_urls,
                             optionsText: 'name',
                             optionsValue: 'url',
-                            selectedOptions settings.api_base_url
+                            selectedOptions: settings.api_base_url
                         "
                         required=""
                     ></select>


### PR DESCRIPTION
0.13.2 update had small bug which prevented the selected URL from being used. (see https://github.com/luizbon/OctoPrint-PSUControl-Meross/pull/1/commits/67152520fc77c9de7407f325fd095dd4aa5bee77)

Additionally, the dependency of meross-iot library needed to be updated to version 0.4.6.0 to make it really work with the API changes Meross introduced in January 2024.